### PR TITLE
Separate scopes by spaces in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Depending on the configured url you can initial the request through:
 
 Or with options:
 
-    /auth/google?scope=email,profile
+    /auth/google?scope=email%20profile
 
 By default the requested scope is "profile". Scope can be configured either explicitly as a `scope` query value on the request path or in your configuration:
 
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
-    google: {Ueberauth.Strategy.Google, [default_scope: "emails,profile,plus.me"]}
+    google: {Ueberauth.Strategy.Google, [default_scope: "emails profile plus.me"]}
   ]
 ```
 


### PR DESCRIPTION
According to the OAuth spec
(http://tools.ietf.org/html/rfc6749#section-3.3) scopes should be
separated by spaces and not commas. I couldn't get multiple scopes to
work successfully using commas with Google APIs.