### PR TITLE
Use the OpenID endpoint to get user profile info

### DIFF
--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -9,8 +9,6 @@ defmodule Ueberauth.Strategy.Google do
   alias Ueberauth.Auth.Credentials
   alias Ueberauth.Auth.Extra
 
-  @token_url "https://www.googleapis.com/plus/v1/people/me/openIdConnect"
-
   @doc """
   Handles initial request for Google authentication.
   """
@@ -112,7 +110,10 @@ defmodule Ueberauth.Strategy.Google do
 
   defp fetch_user(conn, token) do
     conn = put_private(conn, :google_token, token)
-    resp = OAuth2.AccessToken.get(token, @token_url)
+
+    # userinfo_endpoint from https://accounts.google.com/.well-known/openid-configuration
+    path = "https://www.googleapis.com/oauth2/v3/userinfo"
+    resp = OAuth2.AccessToken.get(token, path)
 
     case resp do
       { :ok, %OAuth2.Response{status_code: 401, body: _body}} ->


### PR DESCRIPTION
See discussion in #9. This new endpoint for obtaining user information returns almost the same information as the old endpoint, but does not require turning on the Google+ API. This follows the OpenID Connect directions at https://developers.google.com/identity/protocols/OpenIDConnect#obtaininguserprofileinformation instead of the Google Sign-In directions.

When testing with my Google account, I found a couple of very minor differences in the bodies of the responses from these two endpoints:

1. The current endpoint returns a ```picture``` URL with a ```sz=50``` query string, which links to a small photo. The OpenID endpoint returns the same URL but with no query string, which links to a large version of the same photo.
2. The current endpoint contains ```"kind" => "plus#personOpenIdConnect",```, and the new OpenID endpoint omits this field.

I also renamed ```@token_url``` to avoid confusion with https://github.com/ueberauth/ueberauth_google/blob/master/lib/ueberauth/strategy/google/oauth.ex#L17. ```@token_url``` was actually not a URL for exchanging an authorization code for an access token, as the variable name implied. Instead, it was just an endpoint to retrieve user info once already authenticated with Google.