### PR TITLE
fix: elixir warns that the variable opts is unsafe

### DIFF
--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -15,7 +15,7 @@ defmodule Ueberauth.Strategy.Google do
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
     opts = [ scope: scopes ]
-    if conn.params["state"], do: opts = Keyword.put(opts, :state, conn.params["state"])
+    opts = if conn.params["state"], do: Keyword.put(opts, :state, conn.params["state"]), else: opts
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
 
     redirect!(conn, Ueberauth.Strategy.Google.OAuth.authorize_url!(opts))


### PR DESCRIPTION
With elixir 1.3.2 there is a warning:

warning: the variable "opts" is unsafe as it has been set inside a case/cond/receive/if/&&/||.
