### PR TITLE
Support Google's hd (hosted domain) parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
+You can also pass the `hd` parameter to limit sign-in to a particular Google Apps hosted domain.
+
+```elixir
+config :ueberauth, Ueberauth,
+  providers: [
+    google: {Ueberauth.Strategy.Google, [hd: "example.com"]}
+  ]
+```
+
+To guard against client-side request modification, it's important to still check the domain in `info.urls[:website]` within the `Ueberauth.Auth` struct if you want to limit sign-in to a specific domain.
+
 ## License
 
 Please see [LICENSE](https://github.com/ueberauth/ueberauth_google/blob/master/LICENSE) for licensing details.

--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -3,7 +3,7 @@ defmodule Ueberauth.Strategy.Google do
   Google Strategy for Überauth.
   """
 
-  use Ueberauth.Strategy, uid_field: :sub, default_scope: "email"
+  use Ueberauth.Strategy, uid_field: :sub, default_scope: "email", hd: nil
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials
@@ -16,6 +16,7 @@ defmodule Ueberauth.Strategy.Google do
     scopes = conn.params["scope"] || option(conn, :default_scope)
     opts = [ scope: scopes ]
     opts = if conn.params["state"], do: Keyword.put(opts, :state, conn.params["state"]), else: opts
+    opts = if option(conn, :hd), do: Keyword.put(opts, :hd, option(conn, :hd)), else: opts
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
 
     redirect!(conn, Ueberauth.Strategy.Google.OAuth.authorize_url!(opts))


### PR DESCRIPTION
The `hd` parameter lets you only accept logins from a specific domain. If users are signed in with multiple accounts, this skips the "select your account" page, which makes login quicker. Documented [here](https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters).


It's worth noting that users can tamper with the URL, so you still have to check the response.

I went for `hd` as that's what the parameter is called, and it's how the Google documentation refers to it. Using `hosted_domain` would be more descriptive and wouldn't clash with the Elixir [`hd` function](http://elixir-lang.org/docs/stable/elixir/Kernel.html#hd/1), but I figured consistency with the Google documentation was a higher priority.