### PR TITLE
Support more parameters for google OAuth access

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
-You can also pass the `hd` parameter to limit sign-in to a particular Google Apps hosted domain.
+You can also pass options such as the `hd` parameter to limit sign-in to a particular Google Apps hosted domain, or `approval_prompt` and `access_type` options to request refresh_tokens and offline access.
 
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
-    google: {Ueberauth.Strategy.Google, [hd: "example.com"]}
+    google: {Ueberauth.Strategy.Google, [hd: "example.com", approval_prompt: "force", access_type: "offline"]}
   ]
 ```
 


### PR DESCRIPTION
For a web application that needs to access a google account when the
user is present (e.g. polling for analytics) the `approval_prompt` and
`access_type` parameters are required. 

[See the docs](https://developers.google.com/youtube/2.0/developers_guide_protocol_oauth2#OAuth2_Server_Side_Web_Applications_Flow) for more details 

This PR adds the ability to add these options to the request. I've slightly refactored how the `opts` are put together.

Let me know what you think and if there's anything I should change.