### PR TITLE
Take token type from oauth response

### DIFF
--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -76,7 +76,7 @@ defmodule Ueberauth.Strategy.Google do
       expires: !!token.expires_at,
       expires_at: token.expires_at,
       scopes: scopes,
-      token_type: token.token_type,
+      token_type: Map.get(token, :token_type),
       refresh_token: token.refresh_token,
       token: token.access_token
     }

--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -76,6 +76,7 @@ defmodule Ueberauth.Strategy.Google do
       expires: !!token.expires_at,
       expires_at: token.expires_at,
       scopes: scopes,
+      token_type: token.token_type,
       refresh_token: token.refresh_token,
       token: token.access_token
     }


### PR DESCRIPTION
Everything works because google always sends "Bearer" token type and it is the default type for oauth2 library. It's probably smarter to manually take it from the response just in case google or oauth2 will introduce changes.