### PR TITLE
Allow access_type config as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v 0.6.0
+
+* Add support for access_type per request using url parameter
+
 # v 0.5.0
 
 * Add support for new params: access_type, approval_prompt, state.

--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -20,6 +20,7 @@ defmodule Ueberauth.Strategy.Google do
       |> with_optional(:hd, conn)
       |> with_optional(:approval_prompt, conn)
       |> with_optional(:access_type, conn)
+      |> with_param(:access_type, conn)
       |> with_param(:prompt, conn)
       |> with_param(:state, conn)
       |> Keyword.put(:redirect_uri, callback_url(conn))


### PR DESCRIPTION
This will allow to override access_type for specific auth flow.