### PR TITLE
fixes crash on regular OAuth callback errors

### DIFF
--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -32,13 +32,13 @@ defmodule Ueberauth.Strategy.Google do
   Handles the callback from Google.
   """
   def handle_callback!(%Plug.Conn{params: %{"code" => code}} = conn) do
+    params = [code: code]
     opts = [redirect_uri: callback_url(conn)]
-    token = Ueberauth.Strategy.Google.OAuth.get_token!([code: code], opts)
-
-    if token.access_token == nil do
-      set_errors!(conn, [error(token.other_params["error"], token.other_params["error_description"])])
-    else
-      fetch_user(conn, token)
+    case Ueberauth.Strategy.Google.OAuth.get_access_token(params, opts) do
+      {:ok, token} ->
+        fetch_user(conn, token)
+      {:error, {error_code, error_description}} ->
+        set_errors!(conn, [error(error_code, error_description)])
     end
   end
 

--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -51,12 +51,16 @@ defmodule Ueberauth.Strategy.Google.OAuth do
     |> OAuth2.Client.get(url, headers, opts)
   end
 
-  def get_token!(params \\ [], opts \\ []) do
-    client =
-      opts
-      |> client
-      |> OAuth2.Client.get_token!(params)
-    client.token
+  def get_access_token(params \\ [], opts \\ []) do
+    case opts |> client |> OAuth2.Client.get_token(params) do
+      {:error, %{body: %{"error" => error, "error_description" => description}}} ->
+        {:error, {error, description}}
+      {:ok, %{token: %{access_token: nil} = token}} ->
+        %{"error" => error, "error_description" => description} = token.other_params
+        {:error, {error, description}}
+      {:ok, %{token: token}} ->
+        {:ok, token}
+    end
   end
 
   # Strategy Callbacks


### PR DESCRIPTION
- for example, redeeming the code again would crash because the strategy was using `OAuth2.Client.get_token!`, which attempts to illegially raise an exception using a OAuth response struct

- Google callbacks are issued with GET so if the auth handler rejects and the user refreshes then the app will crash

 - in this set of changes the problem is fixed and the function in `Ueberauth.Strategy.Google.OAuth` is renamed

![screen shot 2017-09-01 at 15 40 55](https://user-images.githubusercontent.com/104086/29975896-0bf47848-8f30-11e7-8bfb-5360b00a0e55.png)

![screen shot 2017-09-01 at 15 40 55](https://user-images.githubusercontent.com/104086/29975909-14903d52-8f30-11e7-99f8-76d1d52311f4.png)