### PR TITLE
Corrected "email" scope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ By default the requested scope is "email". Scope can be configured either explic
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
-    google: {Ueberauth.Strategy.Google, [default_scope: "emails profile plus.me"]}
+    google: {Ueberauth.Strategy.Google, [default_scope: "email profile plus.me"]}
   ]
 ```
 


### PR DESCRIPTION
This is related to #44 

See https://developers.google.com/identity/protocols/googlescopes for
more information in the "Google Sign-In" section.