### PR TITLE
Replace deprecated approval_prompt with prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
-You can also pass options such as the `hd` parameter to limit sign-in to a particular Google Apps hosted domain, or `approval_prompt` and `access_type` options to request refresh_tokens and offline access.
+You can also pass options such as the `hd` parameter to limit sign-in to a particular Google Apps hosted domain, or `prompt` and `access_type` options to request refresh_tokens and offline access.
 
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
-    google: {Ueberauth.Strategy.Google, [hd: "example.com", approval_prompt: "force", access_type: "offline"]}
+    google: {Ueberauth.Strategy.Google, [hd: "example.com", prompt: "select_account", access_type: "offline"]}
   ]
 ```
 

--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -18,7 +18,7 @@ defmodule Ueberauth.Strategy.Google do
     opts =
       [scope: scopes]
       |> with_optional(:hd, conn)
-      |> with_optional(:approval_prompt, conn)
+      |> with_optional(:prompt, conn)
       |> with_optional(:access_type, conn)
       |> with_param(:access_type, conn)
       |> with_param(:prompt, conn)


### PR DESCRIPTION
`approval_prompt` has been deprecated and no longer works. It has been replaced by the `prompt` option. You can see the list of parameters here:
https://developers.google.com/identity/protocols/OAuth2WebServer#creatingclient

In the future, it may be worth considering an alternate strategy of just passing through all options directly so a code update isn't necessary every time the options change.

Resolves #49 and is the same as #50 except it renames `prompt` to `approval_prompt` because the later is no longer honored by Google's OAuth.