### PR TITLE
Create travis.yml with language: elixir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: elixir


### PR DESCRIPTION
Looks like travis wasn't recognizing the project as an Elixir project, this is an attempt to do the bare minimum to let Travis pass. 