### PR TITLE
Fixed redirect_uri from config

### DIFF
--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -15,7 +15,7 @@ defmodule Ueberauth.Strategy.Google do
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
 
-    opts =
+    params =
       [scope: scopes]
       |> with_optional(:hd, conn)
       |> with_optional(:prompt, conn)
@@ -23,9 +23,10 @@ defmodule Ueberauth.Strategy.Google do
       |> with_param(:access_type, conn)
       |> with_param(:prompt, conn)
       |> with_param(:state, conn)
-      |> Keyword.put(:redirect_uri, callback_url(conn))
 
-    redirect!(conn, Ueberauth.Strategy.Google.OAuth.authorize_url!(opts))
+    opts = [redirect_uri: callback_url(conn)]
+
+    redirect!(conn, Ueberauth.Strategy.Google.OAuth.authorize_url!(params, opts))
   end
 
   @doc """

--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -29,8 +29,8 @@ defmodule Ueberauth.Strategy.Google.OAuth do
 
     opts =
       @defaults
-      |> Keyword.merge(config)
       |> Keyword.merge(opts)
+      |> Keyword.merge(config)
 
     OAuth2.Client.new(opts)
   end


### PR DESCRIPTION
## MOTIVATION
I don't want to see strange mistakes. 

## Reason
I want to use ueberauth_google in my API

## Description
I have a front-end and back-end (JSON API) part.
I would like to add ueberauth_google to the back-end and use this on the front-end.
Now the current implementation does not allow me to do it.
Below I will give examples of why I can not do this.

The front-end page is on https://d8765e7f.ngrok.io/test
The back-end page will be on https://d8765e7f.ngrok.io/api/v1/auth/google/callback

> d8765e7f.ngrok.io - local example

**My files**:
config
```elixir
config :ueberauth, Ueberauth,
  base_path: "/api/v1/auth",
  providers: [
    github: {Ueberauth.Strategy.Github, []},
    google: { Ueberauth.Strategy.Google, [] },
    identity: { Ueberauth.Strategy.Identity, [
        callback_methods: ["POST"],
        uid_field: :username,
        nickname_field: :username,
      ] },
  ]

config :ueberauth, Ueberauth.Strategy.Google.OAuth,
  client_id: "SECRET",
  client_secret: "SECRET"
```

router
```elixir
  scope "/api/v1/auth", TestProject do
    pipe_through [:api]

    get "/:provider", AuthController, :request
    get "/:provider/callback", AuthController, :callback
    post "/:provider/callback", AuthController, :callback
  end
```
controller
```elixir
defmodule TestProject.AuthController do
  use TestProject.Web, :controller
  plug Ueberauth

  alias TestProject.{AuthUser, User, UserView, ErrorView}

  plug :scrub_params, "user" when action in [:sign_in_user]

  def request(_params) do
  end


  def callback(%{assigns: %{ueberauth_failure: fails}} = conn, params) do
    conn
    |> put_status(401)
    |> render(ErrorView, "401.json")
  end

  def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
    import IEx
    pry

```

### The first case

Change config

From
```elixir
    github: {Ueberauth.Strategy.Github, []},
```

To
```elixir
    github: {Ueberauth.Strategy.Github, [callback_path: "/test"]},
```

This helped me but the `` plug Ueberauth`` with `` /api/v1/auth/google/callback`` did not work for me.
My ``conn.assigns`` was empty.

### The second case

Change config

From
```elixir
config :ueberauth, Ueberauth.Strategy.Google.OAuth,
  client_id: "SECRET",
  client_secret: "SECRET"
```

To
```elixir
config :ueberauth, Ueberauth.Strategy.Google.OAuth,
  client_id: "SECRET",
  client_secret: "SECRET",
  redirect_uri: "https://d8765e7f.ngrok.io/test"
```

Nothing happened.

### The third case

Change path "/api/v1/auth/google/callback" on "test"

From
```elixir
https://accounts.google.com/o/oauth2/v2/auth?client_id=239.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Fd8765e7f.ngrok.io%2Fapi%2Fv1%2Fauth%2Fgoogle%2Fcallback&response_type=code&scope=email
```

To
```elixir
https://accounts.google.com/o/oauth2/v2/auth?client_id=239.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Fd8765e7f.ngrok.io%2Ftest&response_type=code&scope=email
```

And I see
```elixir
%{ueberauth_failure: %Ueberauth.Failure{errors: [%Ueberauth.Failure.Error{message: "Bad Request",
     message_key: "redirect_uri_mismatch"}], provider: :google,
   strategy: Ueberauth.Strategy.Google}
```

## Result

After https://d8765e7f.ngrok.io/api/v1/auth/google/ I moving to https://d8765e7f.ngrok.io/test and I can easily send a request to https://d8765e7f.ngrok.io/api/v1/auth/google/callback
In my terminal

### Before
```elixir
config :ueberauth, Ueberauth.Strategy.Google.OAuth,
  client_id: "SECRET",
  client_secret: "SECRET",
  redirect_uri: "https://d8765e7f.ngrok.io/test"
```
```elixir
%{ueberauth_failure: %Ueberauth.Failure{errors: [%Ueberauth.Failure.Error{message: "Bad Request",
     message_key: "redirect_uri_mismatch"}], provider: :google,
   strategy: Ueberauth.Strategy.Google}
```

### After
```elixir
config :ueberauth, Ueberauth.Strategy.Google.OAuth,
  client_id: "SECRET",
  client_secret: "SECRET",
  redirect_uri: "https://d8765e7f.ngrok.io/test"
```
```elixir
%{ueberauth_auth: %Ueberauth.Auth{...}}
```

## Tested
**Environment:**
- Elixir Version: 1.4.4
- Erlang Version: Erlang/OTP 20
- Operating System: macOS 10.13.4 (17E202)

## Changes
- [x] Fixed redirect_uri from config
