### PR TITLE
Amends Google strategy to resolve m/f/a tuples

### DIFF
--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -146,5 +146,9 @@ defmodule Ueberauth.Strategy.Google do
 
   defp option(conn, key) do
     Keyword.get(options(conn), key, Keyword.get(default_options(), key))
+    |> resolve_value()
   end
+
+  defp resolve_value({m, f, a}) when is_atom(m) and is_atom(f), do: apply(m, f, a)
+  defp resolve_value(v), do: v
 end


### PR DESCRIPTION
- this allows specifying {m, f, a} tuples for things such as Client ID / Client Secret