### PR TITLE
Added information about reading client_id/client_secret from MFA to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,22 @@
 
 1.  Update your provider configuration:
 
+    Use that if you want to read client ID/secret from the environment 
+    variables in the compile time:
+
     ```elixir
     config :ueberauth, Ueberauth.Strategy.Google.OAuth,
       client_id: System.get_env("GOOGLE_CLIENT_ID"),
       client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
+    ```
+
+    Use that if you want to read client ID/secret from the environment 
+    variables in the run time:
+
+    ```elixir
+    config :ueberauth, Ueberauth.Strategy.Google.OAuth,
+      client_id: {System, :get_env, ["GOOGLE_CLIENT_ID"]},
+      client_secret: {System, :get_env, ["GOOGLE_CLIENT_SECRET"]}
     ```
 
 1.  Include the Überauth plug in your controller:


### PR DESCRIPTION
#60 added ability to read config vars via MFA but there was no information about that in the README