### PR TITLE
`hd:` doesn't limit login to a domain but only suggests it

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 1.  Update your provider configuration:
 
-    Use that if you want to read client ID/secret from the environment 
+    Use that if you want to read client ID/secret from the environment
     variables in the compile time:
 
     ```elixir
@@ -42,7 +42,7 @@
       client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
     ```
 
-    Use that if you want to read client ID/secret from the environment 
+    Use that if you want to read client ID/secret from the environment
     variables in the run time:
 
     ```elixir
@@ -95,7 +95,7 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
-You can also pass options such as the `hd` parameter to limit sign-in to a particular Google Apps hosted domain, or `prompt` and `access_type` options to request refresh_tokens and offline access.
+You can also pass options such as the `hd` parameter to suggest a particular Google Apps hosted domain (caution, can still be overridden by the user), or `prompt` and `access_type` options to request refresh_tokens and offline access.
 
 ```elixir
 config :ueberauth, Ueberauth,


### PR DESCRIPTION
The previous wording was misleading as it could be interpreted
as a security mechanism which it definitely isn't.

I tried this out so this is what the login looks like:

![Selection_146](https://user-images.githubusercontent.com/606517/63578240-53004580-c590-11e9-9e92-a868795587f6.png)

However, you can simply fill in any email address:

![Selection_147](https://user-images.githubusercontent.com/606517/63578261-5dbada80-c590-11e9-8aa9-2ced7e011628.png)

--> validation still required on the app side.

