### PR TITLE
Add support for optional include_granted_scopes param

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
-You can also pass options such as the `hd` parameter to suggest a particular Google Apps hosted domain (caution, can still be overridden by the user), or `prompt` and `access_type` options to request refresh_tokens and offline access.
+You can also pass options such as the `hd` parameter to suggest a particular Google Apps hosted domain (caution, can still be overridden by the user), `prompt` and `access_type` options to request refresh_tokens and offline access (both have to be present), or `include_granted_scopes` parameter to allow [incremental authorization](https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth).
 
 ```elixir
 config :ueberauth, Ueberauth,
   providers: [
-    google: {Ueberauth.Strategy.Google, [hd: "example.com", prompt: "select_account", access_type: "offline"]}
+    google: {Ueberauth.Strategy.Google, [hd: "example.com", prompt: "select_account", access_type: "offline", include_granted_scopes: true]}
   ]
 ```
 

--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -25,6 +25,7 @@ defmodule Ueberauth.Strategy.Google do
       |> with_optional(:prompt, conn)
       |> with_optional(:access_type, conn)
       |> with_optional(:login_hint, conn)
+      |> with_optional(:include_granted_scopes, conn)
       |> with_param(:access_type, conn)
       |> with_param(:prompt, conn)
       |> with_param(:login_hint, conn)


### PR DESCRIPTION
Closes #78

I also took the liberty of clarifying that the `prompt` and `access_type` have to be both present (as mentioned in #49)

I have tested this in my app and seems to work without any issues :>