### PR TITLE
Fix crash on not handled Oauth2.Error

### DIFF
--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -52,14 +52,17 @@ defmodule Ueberauth.Strategy.Google.OAuth do
 
   def get_access_token(params \\ [], opts \\ []) do
     case opts |> client |> OAuth2.Client.get_token(params) do
-      {:error, %{body: %{"error" => error, "error_description" => description}}} ->
+      {:error, %OAuth2.Response{body: %{"error" => error, "error_description" => description}}} ->
         {:error, {error, description}}
 
-      {:ok, %{token: %{access_token: nil} = token}} ->
+      {:error, %OAuth2.Error{reason: reason}} ->
+        {:error, {"error", to_string(reason)}}
+
+      {:ok, %OAuth2.Client{token: %{access_token: nil} = token}} ->
         %{"error" => error, "error_description" => description} = token.other_params
         {:error, {error, description}}
 
-      {:ok, %{token: token}} ->
+      {:ok, %OAuth2.Client{token: token}} ->
         {:ok, token}
     end
   end


### PR DESCRIPTION
** (CaseClauseError) no case clause matching: {:error, %OAuth2.Error{reason: :timeout}}

See spec for https://hexdocs.pm/oauth2/OAuth2.Client.html#get_token/4
```
get_token(client, params \\ [], headers \\ [], opts \\ [])View Source
get_token(t(), params(), headers(), Keyword.t()) ::
  {:ok, OAuth2.Client.t()}
  | {:error, OAuth2.Response.t()}
  | {:error, OAuth2.Error.t()}
```