### PR TITLE
Prefer Local Over Global Configuration

### DIFF
--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -27,7 +27,7 @@ defmodule Ueberauth.Strategy.Google.OAuth do
   """
   def client(opts \\ []) do
     config = Application.get_env(:ueberauth, __MODULE__, [])
-    opts = @defaults |> Keyword.merge(opts) |> Keyword.merge(config) |> resolve_values()
+    opts = @defaults |> Keyword.merge(config) |> Keyword.merge(opts) |> resolve_values()
     json_library = Ueberauth.json_library()
 
     OAuth2.Client.new(opts)


### PR DESCRIPTION
Hello 👋🏼 

This PR is primarily for discussion purposes, with code as a demonstration.

In the current implementation, if someone configures this provider using the global configuration shown in the README, they cannot then provide a different configuration at the call site. This is because the library overrides local / passed-in configuration options with the global config.

In my opinion, the library should prefer local over global [over the defaults]. This way, different call sites can provide their own options while still falling back to the global config. We intend to use this at CodeSandbox to provide logins via multiple Google OAuth clients — one which is a clear default, and others which are specialized and locally configured.

Always open to feedback and discussion. Thanks!