### PR TITLE
Handle %OAuth2.Response{status_code: 503} with no error_description in get_access_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (Unreleased)
 
+- Handle `%OAuth2.Response{status_code: 503}` with no `error_description` in `get_access_token` [99](https://github.com/ueberauth/ueberauth_google/pull/99)
+
 ## v0.10.2
 
 * Prefer Local Over Global Configuration [95](https://github.com/ueberauth/ueberauth_google/pull/95)

--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -52,7 +52,8 @@ defmodule Ueberauth.Strategy.Google.OAuth do
 
   def get_access_token(params \\ [], opts \\ []) do
     case opts |> client |> OAuth2.Client.get_token(params) do
-      {:error, %OAuth2.Response{body: %{"error" => error, "error_description" => description}}} ->
+      {:error, %OAuth2.Response{body: %{"error" => error}} = response} ->
+        description = Map.get(response.body, "error_description", "")
         {:error, {error, description}}
 
       {:error, %OAuth2.Error{reason: reason}} ->

--- a/test/strategy/google_test.exs
+++ b/test/strategy/google_test.exs
@@ -42,6 +42,9 @@ defmodule Ueberauth.Strategy.GoogleTest do
   def oauth2_get_token(_client, code: "error_response"),
     do: {:error, %OAuth2.Response{body: %{"error" => "some error", "error_description" => "something went wrong"}}}
 
+  def oauth2_get_token(_client, code: "error_response_no_description"),
+    do: {:error, %OAuth2.Response{body: %{"error" => "some error"}}}
+
   def oauth2_get(%{token: %{access_token: "success_token"}}, _url, _, _),
     do: response(%{"sub" => "1234_fred", "name" => "Fred Jones", "email" => "fred_jones@example.com"})
 
@@ -177,6 +180,22 @@ defmodule Ueberauth.Strategy.GoogleTest do
 
       assert %Ueberauth.Failure{
                errors: [%Ueberauth.Failure.Error{message: "something went wrong", message_key: "some error"}]
+             } = failure
+    end
+
+    test "handle_callback! handles error response without error_description", %{
+      csrf_state: csrf_state,
+      csrf_conn: csrf_conn
+    } do
+      conn =
+        conn(:get, "/auth/google/callback", %{code: "error_response_no_description", state: csrf_state})
+        |> set_csrf_cookies(csrf_conn)
+
+      routes = Ueberauth.init([])
+      assert %Plug.Conn{assigns: %{ueberauth_failure: failure}} = Ueberauth.call(conn, routes)
+
+      assert %Ueberauth.Failure{
+               errors: [%Ueberauth.Failure.Error{message: "", message_key: "some error"}]
              } = failure
     end
   end

--- a/test/strategy/google_test.exs
+++ b/test/strategy/google_test.exs
@@ -43,7 +43,7 @@ defmodule Ueberauth.Strategy.GoogleTest do
     do: {:error, %OAuth2.Response{body: %{"error" => "some error", "error_description" => "something went wrong"}}}
 
   def oauth2_get_token(_client, code: "error_response_no_description"),
-    do: {:error, %OAuth2.Response{body: %{"error" => "some error"}}}
+    do: {:error, %OAuth2.Response{body: %{"error" => "internal_failure"}}}
 
   def oauth2_get(%{token: %{access_token: "success_token"}}, _url, _, _),
     do: response(%{"sub" => "1234_fred", "name" => "Fred Jones", "email" => "fred_jones@example.com"})
@@ -195,7 +195,7 @@ defmodule Ueberauth.Strategy.GoogleTest do
       assert %Plug.Conn{assigns: %{ueberauth_failure: failure}} = Ueberauth.call(conn, routes)
 
       assert %Ueberauth.Failure{
-               errors: [%Ueberauth.Failure.Error{message: "", message_key: "some error"}]
+               errors: [%Ueberauth.Failure.Error{message: "", message_key: "internal_failure"}]
              } = failure
     end
   end


### PR DESCRIPTION
closes https://github.com/ueberauth/ueberauth_google/issues/98