### PR TITLE
Fix "Requested Erlang/OTP version (22.3) not found in version list " on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
 jobs:
   Test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -28,13 +28,13 @@ jobs:
         run: mix test
 
   Linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
       - name: Set up Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.11'
           otp-version: '22.3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir


### PR DESCRIPTION
I opened another PR and its CI is failing with this error:

```
Run erlef/setup-elixir@v1
  with:
    elixir-version: 1.11
    otp-version: 22.3
    github-token: ***
    install-hex: true
    install-rebar: true
    version-type: loose
    disable_problem_matchers: false
    hexpm-mirrors: https://builds.hex.pm/
  
Error: Requested Erlang/OTP version (22.3) not found in version list (should you be using option 'version-type': 'strict'?)
```

I have seen this error before. It happened in my project unexpectedly. It happened when the tag `ubuntu-latest` upgraded from 20.04 to 22.04, which no longer supports some older Erlang versions according to this table: https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp