### PR TITLE
Add the option to get the client secret dynamically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## (Unreleased)
 
+## v0.11.0
+
+* Allow using a function to generate the client secret [101](https://github.com/ueberauth/ueberauth_google/pull/101)
+
 ## v0.10.3
 
-- Handle `%OAuth2.Response{status_code: 503}` with no `error_description` in `get_access_token` [99](https://github.com/ueberauth/ueberauth_google/pull/99)
+* Handle `%OAuth2.Response{status_code: 503}` with no `error_description` in `get_access_token` [99](https://github.com/ueberauth/ueberauth_google/pull/99)
 
 ## v0.10.2
 

--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -27,17 +27,14 @@ defmodule Ueberauth.Strategy.Google.OAuth do
   """
   def client(opts \\ []) do
     config = Application.get_env(:ueberauth, __MODULE__, [])
-
-    opts =
-      @defaults
-      |> Keyword.merge(config)
-      |> Keyword.merge(opts)
-      |> resolve_values()
-      |> generate_secret()
-
     json_library = Ueberauth.json_library()
 
-    OAuth2.Client.new(opts)
+    @defaults
+    |> Keyword.merge(config)
+    |> Keyword.merge(opts)
+    |> resolve_values()
+    |> generate_secret()
+    |> OAuth2.Client.new()
     |> OAuth2.Client.put_serializer("application/json", json_library)
   end
 

--- a/lib/ueberauth/strategy/google/oauth.ex
+++ b/lib/ueberauth/strategy/google/oauth.ex
@@ -27,7 +27,14 @@ defmodule Ueberauth.Strategy.Google.OAuth do
   """
   def client(opts \\ []) do
     config = Application.get_env(:ueberauth, __MODULE__, [])
-    opts = @defaults |> Keyword.merge(config) |> Keyword.merge(opts) |> resolve_values()
+
+    opts =
+      @defaults
+      |> Keyword.merge(config)
+      |> Keyword.merge(opts)
+      |> resolve_values()
+      |> generate_secret()
+
     json_library = Ueberauth.json_library()
 
     OAuth2.Client.new(opts)
@@ -89,4 +96,14 @@ defmodule Ueberauth.Strategy.Google.OAuth do
 
   defp resolve_value({m, f, a}) when is_atom(m) and is_atom(f), do: apply(m, f, a)
   defp resolve_value(v), do: v
+
+  defp generate_secret(opts) do
+    if is_tuple(opts[:client_secret]) do
+      {module, fun} = opts[:client_secret]
+      secret = apply(module, fun, [opts])
+      Keyword.put(opts, :client_secret, secret)
+    else
+      opts
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule UeberauthGoogle.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth_google"
-  @version "0.10.3"
+  @version "0.11.0"
 
   def project do
     [

--- a/test/strategy/google/oauth_test.exs
+++ b/test/strategy/google/oauth_test.exs
@@ -1,5 +1,5 @@
 defmodule Ueberauth.Strategy.Google.OAuthTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Ueberauth.Strategy.Google.OAuth
 

--- a/test/strategy/google/oauth_test.exs
+++ b/test/strategy/google/oauth_test.exs
@@ -1,0 +1,20 @@
+defmodule Ueberauth.Strategy.Google.OAuthTest do
+  use ExUnit.Case
+
+  alias Ueberauth.Strategy.Google.OAuth
+
+  defmodule MyApp.Google do
+    def client_secret(_opts), do: "custom_client_secret"
+  end
+
+  describe "client/1" do
+    test "uses client secret in the config when it is not a tuple" do
+      assert %OAuth2.Client{client_secret: "client_secret"} = OAuth.client()
+    end
+
+    test "generates client secret when it is using a tuple config" do
+      options = [client_secret: {MyApp.Google, :client_secret}]
+      assert %OAuth2.Client{client_secret: "custom_client_secret"} = OAuth.client(options)
+    end
+  end
+end


### PR DESCRIPTION
Add the possibility to get the client secret from a module in order to rotate the secret at least every 6 months (which is a good practice) without the need to be changing the config or env var and restart the application. Similar to the implementation of ueberauth_apple: https://github.com/ueberauth/ueberauth_apple/blob/main/guides/getting-started.md#generating-the-client-secret

Configuration would look like this:
```elixir
config :ueberauth, Ueberauth.Strategy.Google.OAuth,
  client_id: System.get_env("GOOGLE_CLIENT_ID"),
  client_secret: {MyApp.Google, :client_secret}
```

and then:
```elixir
defmodule MyApp.Google
  @spec client_secret(config :: keyword) :: String.t()
  def client_secret(_config \\ []) do
    # Get client secret from db, cache or any other custom implementation.
  end
end
```

This does not affect to the current implementation, it is backwards compatible.
What do you think? @yordis 