### PR TITLE
Add support to hl param in authorization URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## (Unreleased)
 
+## v0.12.0
+
+* Add support to hl param in handle_request! [102](https://github.com/ueberauth/ueberauth_google/pull/102)
+
 ## v0.11.0
 
 * Allow using a function to generate the client secret [101](https://github.com/ueberauth/ueberauth_google/pull/101)

--- a/lib/ueberauth/strategy/google.ex
+++ b/lib/ueberauth/strategy/google.ex
@@ -29,6 +29,7 @@ defmodule Ueberauth.Strategy.Google do
       |> with_param(:access_type, conn)
       |> with_param(:prompt, conn)
       |> with_param(:login_hint, conn)
+      |> with_param(:hl, conn)
       |> with_state_param(conn)
 
     opts = oauth_client_options_from_conn(conn)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule UeberauthGoogle.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/ueberauth/ueberauth_google"
-  @version "0.11.0"
+  @version "0.12.0"
 
   def project do
     [

--- a/test/strategy/google_test.exs
+++ b/test/strategy/google_test.exs
@@ -68,7 +68,7 @@ defmodule Ueberauth.Strategy.GoogleTest do
   end
 
   test "handle_request! redirects to appropriate auth uri" do
-    conn = conn(:get, "/auth/google", %{})
+    conn = conn(:get, "/auth/google", %{hl: "es"})
     # Make sure the hd and scope params are included for good measure
     routes = Ueberauth.init() |> set_options(conn, hd: "example.com", default_scope: "email openid")
 
@@ -86,7 +86,8 @@ defmodule Ueberauth.Strategy.GoogleTest do
              "redirect_uri" => "http://www.example.com/auth/google/callback",
              "response_type" => "code",
              "scope" => "email openid",
-             "hd" => "example.com"
+             "hd" => "example.com",
+             "hl" => "es"
            } = Plug.Conn.Query.decode(redirect_uri.query)
   end
 


### PR DESCRIPTION
In order to change the locale in the google interface, the param `hl` have to be passed in the authorization url.
List of supported locales: https://serpapi.com/google-languages

Example URL:
```
https://accounts.google.com/o/oauth2/v2/auth?client_id=client_id&hd=example.com&hl=es&redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fgoogle%2Fcallback&response_type=code&scope=email+openid&state=wsX_H_KivcqRx03y5mgmrCDm
```

What do you think? @yordis 